### PR TITLE
Update docker-compose image references from v3.4.2 to v4.2.0 on lab 3

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ free5GLabs is a comprehensive educational repository containing hands-on labs fo
   ```bash
   cd lab3/exercise
   docker pull mongo:latest  # ~9 seconds
-  docker pull free5gc/nrf:v3.4.2  # ~1-2 seconds
+  docker pull free5gc/nrf:v4.2.0  # ~1-2 seconds
   ```
 - **TIMING**: Individual pulls 1-15 seconds, full deployment setup 2-5 minutes
 - **NEVER CANCEL**: Set timeout to 15+ minutes for complete lab3 deployment
@@ -69,7 +69,7 @@ free5GLabs is a comprehensive educational repository containing hands-on labs fo
 
 ### Lab 3 - Docker Deployment Validation
 **CRITICAL**: After Docker setup changes, ALWAYS validate full deployment:
-- Test image pulls: `docker pull free5gc/nrf:v3.4.2`
+- Test image pulls: `docker pull free5gc/nrf:v4.2.0`
 - Verify network bridges: `brctl show` (should show docker0 and potentially br-free5gc)
 - **Manual validation**: Deploy core services and verify connectivity between NFs
 - **Check logs**: Each NF should start successfully and register with NRF

--- a/lab3/ans/deploy_ans.yaml
+++ b/lab3/ans/deploy_ans.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   free5gc-upf:
     container_name: upf
-    image: free5gc/upf:v3.4.2
+    image: free5gc/upf:v4.2.0
     command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
     volumes:
       - ./config/upfcfg.yaml:/free5gc/config/upfcfg.yaml
@@ -51,7 +51,7 @@ services:
 
   free5gc-nrf:
     container_name: nrf
-    image: free5gc/nrf:v3.4.2
+    image: free5gc/nrf:v4.2.0
     command: ./nrf -c ./config/nrfcfg.yaml
     expose:
       - "8000"
@@ -70,7 +70,7 @@ services:
 
   free5gc-amf:
     container_name: amf
-    image: free5gc/amf:v3.4.2
+    image: free5gc/amf:v4.2.0
     command: ./amf -c ./config/amfcfg.yaml
     expose:
       - "8000"
@@ -91,7 +91,7 @@ services:
 
   free5gc-ausf:
     container_name: ausf
-    image: free5gc/ausf:v3.4.2
+    image: free5gc/ausf:v4.2.0
     command: ./ausf -c ./config/ausfcfg.yaml
     expose:
       - "8000"
@@ -109,7 +109,7 @@ services:
 
   free5gc-nssf:
     container_name: nssf
-    image: free5gc/nssf:v3.4.2
+    image: free5gc/nssf:v4.2.0
     command: ./nssf -c ./config/nssfcfg.yaml
     expose:
       - "8000"
@@ -127,7 +127,7 @@ services:
 
   free5gc-pcf:
     container_name: pcf
-    image: free5gc/pcf:v3.4.2
+    image: free5gc/pcf:v4.2.0
     command: ./pcf -c ./config/pcfcfg.yaml
     expose:
       - "8000"
@@ -145,7 +145,7 @@ services:
 
   free5gc-smf:
     container_name: smf
-    image: free5gc/smf:v3.4.2
+    image: free5gc/smf:v4.2.0
     command: ./smf -c ./config/smfcfg.yaml -u ./config/uerouting.yaml
     expose:
       - "8000"
@@ -169,7 +169,7 @@ services:
 
   free5gc-udm:
     container_name: udm
-    image: free5gc/udm:v3.4.2
+    image: free5gc/udm:v4.2.0
     command: ./udm -c ./config/udmcfg.yaml
     expose:
       - "8000"
@@ -188,7 +188,7 @@ services:
 
   free5gc-udr:
     container_name: udr
-    image: free5gc/udr:v3.4.2
+    image: free5gc/udr:v4.2.0
     command: ./udr -c ./config/udrcfg.yaml
     expose:
       - "8000"
@@ -208,7 +208,7 @@ services:
 
   free5gc-chf:
     container_name: chf
-    image: free5gc/chf:v3.4.2
+    image: free5gc/chf:v4.2.0
     command: ./chf -c ./config/chfcfg.yaml
     expose:
       - "8000"
@@ -229,7 +229,7 @@ services:
 
   free5gc-webui:
     container_name: webui
-    image: free5gc/webui:v3.4.2
+    image: free5gc/webui:v4.2.0
     command: ./webui -c ./config/webuicfg.yaml
     expose:
       - "2121"

--- a/lab3/exercise/deploy_exercise.yaml
+++ b/lab3/exercise/deploy_exercise.yaml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   free5gc-upf:
     container_name: upf
-    image: free5gc/upf:v3.4.2
+    image: free5gc/upf:v4.2.0
     command: bash -c "./upf-iptables.sh && ./upf -c ./config/upfcfg.yaml"
     volumes:
       - ./config/upfcfg.yaml:/free5gc/config/upfcfg.yaml
@@ -44,7 +44,7 @@ services:
 
   free5gc-nrf:
     container_name: nrf
-    image: free5gc/nrf:v3.4.2
+    image: free5gc/nrf:v4.2.0
     command: ./nrf -c ./config/nrfcfg.yaml
     expose:
       - "8000"
@@ -63,7 +63,7 @@ services:
 
   free5gc-amf:
     container_name: amf
-    image: free5gc/amf:v3.4.2
+    image: free5gc/amf:v4.2.0
     command: ./amf -c ./config/amfcfg.yaml
     expose:
       - "8000"
@@ -81,7 +81,7 @@ services:
 
   free5gc-ausf:
     container_name: ausf
-    image: free5gc/ausf:v3.4.2
+    image: free5gc/ausf:v4.2.0
     command: ./ausf -c ./config/ausfcfg.yaml
     expose:
       - "8000"
@@ -99,7 +99,7 @@ services:
 
   free5gc-nssf:
     container_name: nssf
-    image: free5gc/nssf:v3.4.2
+    image: free5gc/nssf:v4.2.0
     command: ./nssf -c ./config/nssfcfg.yaml
     expose:
       - "8000"
@@ -117,7 +117,7 @@ services:
 
   free5gc-pcf:
     container_name: pcf
-    image: free5gc/pcf:v3.4.2
+    image: free5gc/pcf:v4.2.0
     command: ./pcf -c ./config/pcfcfg.yaml
     expose:
       - "8000"
@@ -135,7 +135,7 @@ services:
 
   free5gc-smf:
     container_name: smf
-    image: free5gc/smf:v3.4.2
+    image: free5gc/smf:v4.2.0
     command: ./smf -c ./config/smfcfg.yaml -u ./config/uerouting.yaml
     expose:
       - "8000"
@@ -155,7 +155,7 @@ services:
 
   free5gc-udm:
     container_name: udm
-    image: free5gc/udm:v3.4.2
+    image: free5gc/udm:v4.2.0
     command: ./udm -c ./config/udmcfg.yaml
     expose:
       - "8000"
@@ -174,7 +174,7 @@ services:
 
   free5gc-udr:
     container_name: udr
-    image: free5gc/udr:v3.4.2
+    image: free5gc/udr:v4.2.0
     command: ./udr -c ./config/udrcfg.yaml
     expose:
       - "8000"
@@ -194,7 +194,7 @@ services:
 
   free5gc-chf:
     container_name: chf
-    image: free5gc/chf:v3.4.2
+    image: free5gc/chf:v4.2.0
     command: ./chf -c ./config/chfcfg.yaml
     expose:
       - "8000"
@@ -215,7 +215,7 @@ services:
 
   free5gc-webui:
     container_name: webui
-    image: free5gc/webui:v3.4.2
+    image: free5gc/webui:v4.2.0
     command: ./webui -c ./config/webuicfg.yaml
     expose:
       - "2121"


### PR DESCRIPTION
This PR updates the docker-compose image references in both the exercise and the answer from v3.4.2 to v4.2.0.

The previous images were no longer compatible with recent gtp5g releases. Older gtp5g versions (e.g., v8.1.0, the last compatible one) fail to compile on modern Linux kernels (tested on Linux 6.14.0).

Updating to the latest image release restores compatibility and enables the use of the most recent gtp5g versions without build issues.
